### PR TITLE
breaks messages of more than 50 blocks into multiple messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.bak
+.env

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const GithubClient = require('./github');
-const SlackClient = require('./slack');
-const _ = require('lodash');
-const Promise = require('bluebird');
+const GithubClient = require("./github");
+const SlackClient = require("./slack");
+const _ = require("lodash");
+const Promise = require("bluebird");
 
 const token = process.env.GITHUB_TOKEN;
 const webhook = process.env.SLACK_WEBHOOK;
@@ -11,93 +11,128 @@ const githubClient = new GithubClient(token);
 const slackClient = new SlackClient(webhook);
 
 async function doTheThing() {
-    let blocks = [{
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text: `:wave: GitHub Security Alerts Report\n\nThe following repositories have open vulnerability alerts and need your attention.`
-        }
-    }];
+  let blocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:wave: GitHub Security Alerts Report\n\nThe following repositories have open vulnerability alerts and need your attention.`,
+      },
+    },
+  ];
 
-    const repos = await githubClient.getRepos(searchQuery);
+  const repos = await githubClient.getRepos(searchQuery);
 
-    await Promise.map(repos, async ({name, org}) => {
-        const alerts = await githubClient.getVulnerabilities(org, name);
-        const criticalAlerts = _.filter(alerts, { severity: 'critical', dismissed: false });
-        const highAlerts = _.filter(alerts, { severity: 'high', dismissed: false });
-        if (criticalAlerts.length > 0 || highAlerts.length > 0) {
-            blocks.push({ type: 'divider' });
-            blocks = blocks.concat(formatAlertsForSlack({ org, name, criticalAlerts, highAlerts }));
-        }
+  await Promise.map(repos, async ({ name, org }) => {
+    const alerts = await githubClient.getVulnerabilities(org, name);
+    const criticalAlerts = _.filter(alerts, {
+      severity: "critical",
+      dismissed: false,
     });
-
-    blocks.push({
-        type: 'context',
-        elements: [
-            {
-                type: 'mrkdwn',
-                text: `Query: ${searchQuery}`
-            }
-        ]
-    });
-
-    if (process.env.POST_TO_SLACK === 'true') {
-        await slackClient.postMessage({ blocks });
-    } else {
-        console.log(`Slack blocks: ${JSON.stringify(blocks,null,2)}`)
+    const highAlerts = _.filter(alerts, { severity: "high", dismissed: false });
+    if (criticalAlerts.length > 0 || highAlerts.length > 0) {
+      blocks.push({ type: "divider" });
+      blocks = blocks.concat(
+        formatAlertsForSlack({ org, name, criticalAlerts, highAlerts })
+      );
     }
+  });
+
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: `Query: ${searchQuery}`,
+      },
+    ],
+  });
+
+  if (process.env.POST_TO_SLACK === "true") {
+    const allBlocks = breakBlocks(blocks);
+    // await will work with oldschool loops, but nothing requires a callback like array.forEach()
+    for (let i = 0; i < allBlocks.length - 1; i++) {
+      await slackClient.postMessage({ blocks: allBlocks[i] });
+    }
+  } else {
+    console.log(`Slack blocks: ${JSON.stringify(blocks, null, 2)}`);
+  }
 }
 
 function formatAlertsForSlack({ org, name, criticalAlerts, highAlerts }) {
-    const alertsSummary = [];
-    if (criticalAlerts.length > 0) {
-        alertsSummary.push(`${criticalAlerts.length} critical`);
-    }
-    if (highAlerts.length > 0) {
-        alertsSummary.push(`${highAlerts.length} high`);
-    }
+  const alertsSummary = [];
+  if (criticalAlerts.length > 0) {
+    alertsSummary.push(`${criticalAlerts.length} critical`);
+  }
+  if (highAlerts.length > 0) {
+    alertsSummary.push(`${highAlerts.length} high`);
+  }
 
-    const blocks = [{
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text: `*<https://github.com/${org}/${name}|${org}/${name}>*\n${alertsSummary.join(', ')}\n<https://github.com/${org}/${name}/network/alerts|View all>`
-        },
-        accessory: {
-            type: 'image',
-            image_url: 'https://user-images.githubusercontent.com/10406825/85333522-ba846b80-b4a7-11ea-9774-46fa8ca693a4.png',
-            alt_text: 'github'
-        }
-    }];
-    criticalAlerts.forEach((criticalAlert) => {
-        blocks.push(formatAlertForSlack(criticalAlert));
-    });
-    highAlerts.forEach((highAlert) => {
-        blocks.push(formatAlertForSlack(highAlert));
-    });
+  const blocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*<https://github.com/${org}/${name}|${org}/${name}>*\n${alertsSummary.join(
+          ", "
+        )}\n<https://github.com/${org}/${name}/network/alerts|View all>`,
+      },
+      accessory: {
+        type: "image",
+        image_url:
+          "https://user-images.githubusercontent.com/10406825/85333522-ba846b80-b4a7-11ea-9774-46fa8ca693a4.png",
+        alt_text: "github",
+      },
+    },
+  ];
+  criticalAlerts.forEach((criticalAlert) => {
+    blocks.push(formatAlertForSlack(criticalAlert));
+  });
+  highAlerts.forEach((highAlert) => {
+    blocks.push(formatAlertForSlack(highAlert));
+  });
 
-    return blocks;
+  return blocks;
 }
 
 function formatAlertForSlack({ id, package_name, severity, created_at }) {
-    return {
-        type: 'section',
-        block_id: `section-${id}`,
-        fields: [
-            {
-                type: 'mrkdwn',
-                text: `*Package (Severity Level)*\n${package_name} (${severity})`
-            },
-            {
-                type: 'mrkdwn',
-                text: `*Created on*\n${created_at}`
-            }
-        ]
-    }
+  return {
+    type: "section",
+    block_id: `section-${id}`,
+    fields: [
+      {
+        type: "mrkdwn",
+        text: `*Package (Severity Level)*\n${package_name} (${severity})`,
+      },
+      {
+        type: "mrkdwn",
+        text: `*Created on*\n${created_at}`,
+      },
+    ],
+  };
 }
 
-return doTheThing()
-    .catch((err) => {
-        console.log(`It failed :( - ${err.message})`);
-        process.exit(-1);
-    });
+/**
+ * Slack only allows 50 blocks per message, break array of all blocks into groups of at most 50.
+ * Returns an array of arrays of blocks in order.
+ * @param {*} blocks
+ */
+function breakBlocks(blocks) {
+  const maxBlocks = 50;
+  const allBlocks = [];
+  while (blocks.length > maxBlocks) {
+    // I'm sorry for using splice, no one is happy about this
+    // this removes the first maxBlocks array entries from the blocks array and returns them into the chunk array
+    // we push all chunks onto all blocks until we're below the maxBlocks threshold, then add the remaining blocks to the allBlocks array
+    const chunk = blocks.splice(0, maxBlocks);
+    allBlocks.push(chunk);
+  }
+
+  allBlocks.push(blocks);
+  return allBlocks;
+}
+
+return doTheThing().catch((err) => {
+  console.log(`It failed :( - ${err.message})`);
+  process.exit(-1);
+});

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ async function doTheThing() {
   if (process.env.POST_TO_SLACK === "true") {
     const allBlocks = breakBlocks(blocks);
     // await will work with oldschool loops, but nothing requires a callback like array.forEach()
-    for (let i = 0; i < allBlocks.length - 1; i++) {
+    for (let i = 0; i < allBlocks.length; i++) {
       await slackClient.postMessage({ blocks: allBlocks[i] });
     }
   } else {

--- a/index.js
+++ b/index.js
@@ -123,12 +123,15 @@ function breakBlocks(blocks) {
   while (blocks.length > maxBlocks) {
     // I'm sorry for using splice, no one is happy about this
     // this removes the first maxBlocks array entries from the blocks array and returns them into the chunk array
-    // we push all chunks onto all blocks until we're below the maxBlocks threshold, then add the remaining blocks to the allBlocks array
+    // we push chunks onto allBlocks until we're below the maxBlocks threshold
     const chunk = blocks.splice(0, maxBlocks);
     allBlocks.push(chunk);
   }
 
-  allBlocks.push(blocks);
+  if (blocks.length > 0) {
+    // add the remaining blocks to the allBlocks array
+    allBlocks.push(blocks);
+  }
   return allBlocks;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -723,6 +723,12 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "pretty-quick": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "husky": "^4.2.5",
+    "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Slack messages can only contain up to 50 blocks (https://api.slack.com/reference/block-kit/blocks). This PR will take all fully constructed blocks required for the message, then split them into groups of at most 50 and post them one at a time in sequence. This allows us to monitor even more repos and get more alerts! Just what everyone wants!